### PR TITLE
Bugfix/bmi constexpr

### DIFF
--- a/include/warthog/domain/grid.h
+++ b/include/warthog/domain/grid.h
@@ -572,10 +572,15 @@ dir_unit_point(direction_id d) noexcept
 	    | (0b0000 << NORTHWEST_ID * 4) | (0b1010 << SOUTHEAST_ID * 4)
 	    | (0b1000 << SOUTHWEST_ID * 4);
 #if WARTHOG_INTRIN_HAS(BMI2)
-	res.v = _pdep_u32(packed_reldir >> d * 4, 0xC000'C000u);
-#else
+	if !consteval {
+		// _pdep_u32 may not be constexpr
+		res.v = _pdep_u32(packed_reldir >> d * 4, 0xC000'C000u);
+	} else {
+#endif
 	res.p.x = (packed_reldir >> d * 4) & 0b11;
 	res.p.y = (packed_reldir >> (d * 4 + 2)) & 0b11;
+#if WARTHOG_INTRIN_HAS(BMI2)
+	} // end if !consteval
 #endif
 	res.p.x -= 1;
 	res.p.y -= 1;
@@ -605,10 +610,15 @@ dir_unit_point_secic(direction_id d) noexcept
 	// for second-intercardinal, return the intercardinal
 	d = d < 8 ? d : secic_intercardinal(d);
 #if WARTHOG_INTRIN_HAS(BMI2)
-	res.v = _pdep_u32(packed_reldir >> d * 4, 0xC000'C000u);
-#else
+	if !consteval {
+		// _pdep_u32 may not be constexpr
+		res.v = _pdep_u32(packed_reldir >> d * 4, 0xC000'C000u);
+	} else {
+#endif
 	res.p.x = (packed_reldir >> d * 4) & 0b11;
 	res.p.y = (packed_reldir >> (d * 4 + 2)) & 0b11;
+#if WARTHOG_INTRIN_HAS(BMI2)
+	} // end if !consteval
 #endif
 	res.p.x -= 1;
 	res.p.y -= 1;

--- a/include/warthog/domain/grid.h
+++ b/include/warthog/domain/grid.h
@@ -572,13 +572,16 @@ dir_unit_point(direction_id d) noexcept
 	    | (0b0000 << NORTHWEST_ID * 4) | (0b1010 << SOUTHEAST_ID * 4)
 	    | (0b1000 << SOUTHWEST_ID * 4);
 #if WARTHOG_INTRIN_HAS(BMI2)
-	if !consteval {
+	if !consteval
+	{
 		// _pdep_u32 may not be constexpr
 		res.v = _pdep_u32(packed_reldir >> d * 4, 0xC000'C000u);
-	} else {
+	}
+	else
+	{
 #endif
-	res.p.x = (packed_reldir >> d * 4) & 0b11;
-	res.p.y = (packed_reldir >> (d * 4 + 2)) & 0b11;
+		res.p.x = (packed_reldir >> d * 4) & 0b11;
+		res.p.y = (packed_reldir >> (d * 4 + 2)) & 0b11;
 #if WARTHOG_INTRIN_HAS(BMI2)
 	} // end if !consteval
 #endif
@@ -610,13 +613,16 @@ dir_unit_point_secic(direction_id d) noexcept
 	// for second-intercardinal, return the intercardinal
 	d = d < 8 ? d : secic_intercardinal(d);
 #if WARTHOG_INTRIN_HAS(BMI2)
-	if !consteval {
+	if !consteval
+	{
 		// _pdep_u32 may not be constexpr
 		res.v = _pdep_u32(packed_reldir >> d * 4, 0xC000'C000u);
-	} else {
+	}
+	else
+	{
 #endif
-	res.p.x = (packed_reldir >> d * 4) & 0b11;
-	res.p.y = (packed_reldir >> (d * 4 + 2)) & 0b11;
+		res.p.x = (packed_reldir >> d * 4) & 0b11;
+		res.p.y = (packed_reldir >> (d * 4 + 2)) & 0b11;
 #if WARTHOG_INTRIN_HAS(BMI2)
 	} // end if !consteval
 #endif

--- a/include/warthog/util/intrin.h
+++ b/include/warthog/util/intrin.h
@@ -14,6 +14,8 @@
 // Check
 // https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html
 
+#include <warthog/defines.h>
+
 #if defined(__x86_64__) && __has_include(<immintrin.h>)
 #include <immintrin.h>
 #define WARTHOG_INTRIN


### PR DESCRIPTION
Bugfix for BMI2 support.

* bugfix include `<warthog/defines.h>` to import CMake INTRIN user options.
* bugfix wrap all WARTHOG_INTRIN_HAS(BMI2) inside constexpr functions to only be used at non-compile time, uses non-BMI2 version for all consteval calls.